### PR TITLE
Stop shipping raw <picture> tags in the NuGet readme

### DIFF
--- a/WoofWare.WeakHashTable/WoofWare.WeakHashTable.fsproj
+++ b/WoofWare.WeakHashTable/WoofWare.WeakHashTable.fsproj
@@ -20,10 +20,6 @@
       <Compile Include="WeakHashTable.fs" />
       <EmbeddedResource Include="SurfaceBaseline.txt" />
       <EmbeddedResource Include="../version.json" />
-      <None Include="..\README.md">
-        <Pack>True</Pack>
-        <PackagePath>\</PackagePath>
-      </None>
       <None Include="..\logos\light.png">
         <Pack>True</Pack>
         <PackagePath>\</PackagePath>
@@ -32,4 +28,59 @@
     <ItemGroup>
         <PackageReference Update="FSharp.Core" Version="5.0.0" />
     </ItemGroup>
+
+    <!--
+      nuget.org renders the packed readme through Markdig with DisableHtml(), which escapes raw
+      HTML instead of dropping it, and it does not resolve relative image paths at all. The
+      <picture> element that gives GitHub its light/dark logo would therefore appear on the
+      package page as literal tags. Pack a copy with that element removed; on nuget.org the logo
+      is carried by PackageIcon instead.
+    -->
+    <UsingTask TaskName="WriteReadmeWithoutLogo"
+               TaskFactory="RoslynCodeTaskFactory"
+               AssemblyFile="$(MSBuildToolsPath)/Microsoft.Build.Tasks.Core.dll">
+      <ParameterGroup>
+        <Source ParameterType="System.String" Required="true" />
+        <Destination ParameterType="System.String" Required="true" />
+      </ParameterGroup>
+      <Task>
+        <Using Namespace="System.Text.RegularExpressions" />
+        <Code Type="Fragment" Language="cs"><![CDATA[
+string readme = File.ReadAllText(Source);
+string stripped = Regex.Replace(readme, "<picture>[\\s\\S]*?</picture>\\s*", "");
+
+// Any other raw HTML would reach nuget.org as escaped tags, so refuse to pack it. The pattern is
+// CommonMark's own HTML-block condition (a tag at the start of a line, indented at most three
+// spaces), applied after fenced code blocks are removed so that markup shown as an example does
+// not trip it.
+string prose = Regex.Replace(stripped, "(?ms)^```.*?^```", "");
+if (Regex.IsMatch(prose, "(?m)^ {0,3}<[A-Za-z/]"))
+{
+    Log.LogError(
+        "{0} contains raw HTML other than the <picture> logo element. nuget.org escapes raw HTML "
+        + "rather than rendering it, so that markup would appear on the package page as literal "
+        + "tags: express it in CommonMark instead, or teach this task to strip it too.",
+        Source);
+}
+else
+{
+    Directory.CreateDirectory(Path.GetDirectoryName(Destination));
+    if (!File.Exists(Destination) || File.ReadAllText(Destination) != stripped)
+    {
+        File.WriteAllText(Destination, stripped);
+    }
+}
+]]></Code>
+      </Task>
+    </UsingTask>
+    <Target Name="PackReadmeWithoutLogo" BeforeTargets="_GetPackageFiles">
+      <PropertyGroup>
+        <_NuGetReadme>$(MSBuildProjectDirectory)/$(IntermediateOutputPath)nuget-readme/README.md</_NuGetReadme>
+      </PropertyGroup>
+      <WriteReadmeWithoutLogo Source="$(MSBuildProjectDirectory)/../README.md" Destination="$(_NuGetReadme)" />
+      <ItemGroup>
+        <None Include="$(_NuGetReadme)" Pack="true" PackagePath="\" />
+      </ItemGroup>
+    </Target>
+
 </Project>

--- a/WoofWare.WeakHashTable/WoofWare.WeakHashTable.fsproj
+++ b/WoofWare.WeakHashTable/WoofWare.WeakHashTable.fsproj
@@ -47,19 +47,17 @@
         <Using Namespace="System.Text.RegularExpressions" />
         <Code Type="Fragment" Language="cs"><![CDATA[
 string readme = File.ReadAllText(Source);
-string stripped = Regex.Replace(readme, "<picture>[\\s\\S]*?</picture>\\s*", "");
+string stripped = Regex.Replace(readme, "<picture[^>]*>[\\s\\S]*?</picture>\\s*", "", RegexOptions.IgnoreCase);
 
-// Any other raw HTML would reach nuget.org as escaped tags, so refuse to pack it. The pattern is
-// CommonMark's own HTML-block condition (a tag at the start of a line, indented at most three
-// spaces), applied after fenced code blocks are removed so that markup shown as an example does
-// not trip it.
-string prose = Regex.Replace(stripped, "(?ms)^```.*?^```", "");
-if (Regex.IsMatch(prose, "(?m)^ {0,3}<[A-Za-z/]"))
+// A <picture> the pattern above failed to match would reach the package page as literal tags, so
+// check the strip did the job it claims to. Any other raw HTML in the readme leaks the same way,
+// but recognising it reliably would mean reimplementing CommonMark's block grammar here.
+if (Regex.IsMatch(stripped, "</?picture", RegexOptions.IgnoreCase))
 {
     Log.LogError(
-        "{0} contains raw HTML other than the <picture> logo element. nuget.org escapes raw HTML "
-        + "rather than rendering it, so that markup would appear on the package page as literal "
-        + "tags: express it in CommonMark instead, or teach this task to strip it too.",
+        "{0} still contains a <picture> element after the logo strip, so the packed readme would "
+        + "show it on nuget.org as literal tags. Write the logo as a plain <picture> ... "
+        + "</picture> block, or teach this task to match the form used.",
         Source);
 }
 else


### PR DESCRIPTION
The published package page for this library currently shows the literal text `<picture> <source media="(prefers-color-scheme: dark)" …>` under the title, rather than the logo.

nuget.org renders `PackageReadmeFile` through Markdig with `DisableHtml()`, which *removes the HTML block parser*: raw HTML is not dropped but falls through to a paragraph and is escaped. Relative image paths do not resolve there either — nuget.org only renders images from an allow-listed set of domains. So one README cannot both theme-switch on GitHub (which needs `<picture>`) and render cleanly on nuget.org (which needs plain CommonMark).

This packs a copy with the logo element stripped, generated into `obj/` at pack time, instead of `README.md` itself. GitHub keeps the theme-aware logo untouched; on nuget.org the logo is the `PackageIcon`, which is already set here.

The strip runs in a `RoslynCodeTaskFactory` inline task rather than through `WriteLinesToFile`. That task takes *items*, and an item spec is a path, so MSBuild normalises its directory separators: a readme containing a backslash came back with the backslash flipped. (`WoofWare.KnuthPlass`, whose readme has a `"\r"` in an F# sample, is where that showed up.) Doing the read, strip and write in C# avoids the round-trip entirely.

The task then checks its own postcondition — that no `<picture>` survived the strip — and fails the pack if one did. It deliberately does not try to reject *all* raw HTML: that would mean recognising CommonMark's block grammar with a regex, which is both too strict to live with (tilde fences, indented fences, fences closed by EOF) and too weak to rely on (inline HTML, `<!-- -->`). Other raw HTML in a readme still leaks to nuget.org as escaped tags; that is stated in a comment rather than half-enforced.

## Verification

* Packed and unpacked: the packed readme is byte-for-byte the source minus the `<picture>` block.
* Rendered the packed readme through a local `MarkdownPipelineBuilder().DisableHtml()` pipeline — no escaped tags outside code blocks.
* Mutation-tested the guard four ways: unmodified readme packs; a readme with a `~~~xml` fence and an inline `<kbd>` packs (no false positive); `<picture class="logo">` packs *and* is stripped (the earlier pattern shipped that silently); a `</picture >` the pattern cannot match fails the pack with the explanatory message.

Note: I could not use this repo's devshell to verify, because its pinned .NET SDK aborts on my machine (libicu); I packed with a .NET 10 SDK instead. The change is pack-time MSBuild only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
