### PR TITLE
Combine the intermediate path rather than prepending it

### DIFF
--- a/WoofWare.WeakHashTable/WoofWare.WeakHashTable.fsproj
+++ b/WoofWare.WeakHashTable/WoofWare.WeakHashTable.fsproj
@@ -73,7 +73,9 @@ else
     </UsingTask>
     <Target Name="PackReadmeWithoutLogo" BeforeTargets="_GetPackageFiles">
       <PropertyGroup>
-        <_NuGetReadme>$(MSBuildProjectDirectory)/$(IntermediateOutputPath)nuget-readme/README.md</_NuGetReadme>
+        <!-- IntermediateOutputPath is relative to the project by default but absolute under
+             UseArtifactsOutput, so combine rather than prepend. -->
+        <_NuGetReadme>$([System.IO.Path]::Combine('$(MSBuildProjectDirectory)', '$(IntermediateOutputPath)', 'nuget-readme', 'README.md'))</_NuGetReadme>
       </PropertyGroup>
       <WriteReadmeWithoutLogo Source="$(MSBuildProjectDirectory)/../README.md" Destination="$(_NuGetReadme)" />
       <ItemGroup>

--- a/WoofWare.WeakHashTable/WoofWare.WeakHashTable.fsproj
+++ b/WoofWare.WeakHashTable/WoofWare.WeakHashTable.fsproj
@@ -73,8 +73,8 @@ else
     </UsingTask>
     <Target Name="PackReadmeWithoutLogo" BeforeTargets="_GetPackageFiles">
       <PropertyGroup>
-        <!-- IntermediateOutputPath is relative to the project by default but absolute under
-             UseArtifactsOutput, so combine rather than prepend. -->
+        <!-- IntermediateOutputPath is relative to the project by default, but absolute under
+             UseArtifactsOutput; Path.Combine gives the right answer in both cases. -->
         <_NuGetReadme>$([System.IO.Path]::Combine('$(MSBuildProjectDirectory)', '$(IntermediateOutputPath)', 'nuget-readme', 'README.md'))</_NuGetReadme>
       </PropertyGroup>
       <WriteReadmeWithoutLogo Source="$(MSBuildProjectDirectory)/../README.md" Destination="$(_NuGetReadme)" />


### PR DESCRIPTION
Follow-up to the readme-strip target: `IntermediateOutputPath` is relative to the project directory by default, but **absolute** under the SDK's `UseArtifactsOutput` (and under an explicit `BaseIntermediateOutputPath`). Prepending `$(MSBuildProjectDirectory)` then produces `<project>/<absolute path>`, so `dotnet pack -p:UseArtifactsOutput=true` wrote the stripped readme into a `<project>/Users/...` tree inside the source directory instead of into the configured artifacts directory. On Windows the same concatenation would be a malformed double-drive path.

`Path.Combine` returns a rooted second argument unchanged, which is the wanted behaviour in both modes.

Verified in this repo: the property resolves under `obj/` by default and under `artifacts/obj/` with the switch; packing with the switch produces a nupkg whose readme is byte-identical to `main`'s readme minus its `<picture>` element, still carries the icon, and leaves no stray directory in the source tree.

Found by Codex reviewing the same target in `WoofWare.Incremental`; the identical fix is going to every repo that carries it.
